### PR TITLE
Remove plone.app.openid from core, still avalable as addon package.

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -6,7 +6,8 @@ Changelog
 
 Breaking changes:
 
-- *add item here*
+- Remove plone.app.openid from core, still avalable as addon package.
+  [jensens]
 
 New features:
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
         'plone.app.caching',
         'plone.app.dexterity',
         'plone.app.iterate',
-        'plone.app.openid',
         'plone.app.upgrade',
     ],
     )


### PR DESCRIPTION
PR for plone/Products.CMFPlone#1659