### PR TITLE
require archetypes.multilingual

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog
 
 Breaking changes:
 
-- Remove plone.app.openid from core, still avalable as addon package.
+- Remove plone.app.openid from core, still available as addon package.
   [jensens]
 
 New features:
@@ -15,7 +15,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Be sure to require archetypes.multilingual
+  even if it's not required as a dependency of plone.app.multilingual.
+  [davisagli]
 
 
 5.1a2 (2016-08-19)

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
+        'archetypes.multilingual',
         'setuptools',
         'Products.Archetypes',
         'Products.ATContentTypes >= 2.1.3',
@@ -40,4 +41,4 @@ setup(
         'plone.app.iterate',
         'plone.app.upgrade',
     ],
-    )
+)


### PR DESCRIPTION
As long as `Plone` requires `Products.ATContentTypes`, it should also require `archetypes.multilingual` even if `plone.app.multilingual` does not do so.

`plone.app.multilingual` currently does, but I'm going to submit a PR to stop that so that it's possible to install `Products.CMFPlone` without getting ATContentTypes.