### PR TITLE
Add dependency on  distribution.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,11 +5,13 @@
 
 Breaking changes:
 
-- *add item here*
+- Require Python 3.10 as minimum.
+  [maurits]
 
 New features:
 
-- *add item here*
+- Add dependency on `plone.classicui` distribution.
+  [maurits]
 
 Bug fixes:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,8 +15,6 @@ classifiers=
     License :: OSI Approved :: GNU General Public License v2 (GPLv2)
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -40,7 +38,7 @@ project_urls=
 include_package_data = True
 zip_safe = False
 packages =
-python_requires = >= 3.8
+python_requires = >= 3.10
 install_requires =
     setuptools>=36.2
     plone.app.caching
@@ -48,6 +46,7 @@ install_requires =
     plone.app.iterate
     plone.app.multilingual
     plone.app.upgrade
+    plone.classicui
     plone.restapi
     plone.volto
     Products.CMFPlacefulWorkflow


### PR DESCRIPTION
Part of [PLIP 3854](https://github.com/plone/Products.CMFPlone/issues/3854).

Require Python 3.10 as minimum.  This was already the case in Products.CMFPlone, but now also officially here.