### PR TITLE
Update trove classifiers to match actual version support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Update package metadata. [davisagli]
 
 
 ## 6.0.14 (2024-12-19)

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,11 +15,11 @@ classifiers=
     License :: OSI Approved :: GNU General Public License v2 (GPLv2)
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Internet :: WWW/HTTP :: Dynamic Content
 keywords = Plone, CMF, Python, Zope, CMS
 author = Plone Foundation
@@ -40,7 +40,7 @@ project_urls=
 include_package_data = True
 zip_safe = False
 packages =
-python_requires = >= 3.8
+python_requires = >= 3.9
 install_requires =
     setuptools>=36.2
     plone.app.caching

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ project_urls=
 include_package_data = True
 zip_safe = False
 packages =
-python_requires = >= 3.9
+python_requires = >= 3.8
 install_requires =
     setuptools>=36.2
     plone.app.caching


### PR DESCRIPTION
Plone 6.0.14 dropped support for Python 3.8 and added support for 3.13, as documented in https://github.com/plone/documentation/pull/1823 and https://plone.org/download/release-schedule